### PR TITLE
Change socket.error check from 'is' to '=='

### DIFF
--- a/simpletcp/serversocket.py
+++ b/simpletcp/serversocket.py
@@ -77,7 +77,7 @@ class ServerSocket:
                     try:
                         data = sock.recv(self.recv_bytes)
                     except socket.error as e:
-                        if e.errno is errno.ECONNRESET:
+                        if e.errno == errno.ECONNRESET:
                             # Consider 'Connection reset by peer'
                             # the same as reading zero bytes
                             data = None


### PR DESCRIPTION
Using 'is' for the equality comparison yielded wrong output. 
Even though a 'Connection reset by peer' error was occurring, e was still being raised; instead being handled gracefully by setting data = None.

The behavioural difference between 'is' and '==' in this context shown below.

![image](https://user-images.githubusercontent.com/32066188/84621154-2cdfd380-af1d-11ea-81ef-3dd76c17bb60.png)

Hence change 'is' to '==' in the code to handle this error properly.

